### PR TITLE
Push fixperms into www subdirectory

### DIFF
--- a/.salt/fixperms.sls
+++ b/.salt/fixperms.sls
@@ -69,10 +69,14 @@
                while read i; do
                    if [ ! -h "${i}" ]; then
                        if [ -d "${i}" ]; then
-                           chmod 2751 "${i}"
+                           chmod g-s "${i}"
+                           chmod 751 "${i}"
+                           chmod g+s "${i}"
                        fi
                        if [ -f "${i}" ]; then
+                           chmod g-s "$(dirname "${i}")"
                            chmod 0640 "${i}"
+                           chmod g+s "$(dirname "${i}")"
                        fi
                    fi
                done

--- a/.salt/fixperms.sls
+++ b/.salt/fixperms.sls
@@ -59,11 +59,10 @@
              #  --dmode 2771 -u root -g root \
              #  --paths "{{cfg.data_root}}"\
              #  --paths "{{cfg.data_root}}/var";
-             {{locs.resetperms}} -q --no-acls\
-                --fmode 640 --dmode 2751\
-                -u {{cfg.user}} -g {{cfg.group}}\
-                --paths "{{cfg.project_root}}/www"\
-                --excludes=".*files.+";
+             find "{{cfg.project_root}}/www" -type d -path "{{cfg.project_root}}/www/*/files" -prune -o -type d -exec chmod 2751 "{}" \;
+             find "{{cfg.project_root}}/www" -path "{{cfg.project_root}}/www/*/files" -prune -o -type f -exec chmod 0640 "{}" \;
+             chown {{cfg.user}}:{{cfg.group}} "{{cfg.project_root}}/www"
+             chown -R {{cfg.user}}:{{cfg.group}} "{{cfg.project_root}}/www/*"
              {{locs.resetperms}} -q --no-recursive --no-acls\
                --fmode  644 -u {{cfg.user}} -g {{cfg.group}}\
                --paths "{{cfg.project_root}}"/www/sites/default/settings.php\

--- a/.salt/fixperms.sls
+++ b/.salt/fixperms.sls
@@ -59,8 +59,13 @@
              #  --dmode 2771 -u root -g root \
              #  --paths "{{cfg.data_root}}"\
              #  --paths "{{cfg.data_root}}/var";
+             {{locs.resetperms}} -q --no-acls\
+                --fmode 640 --dmode 2751\
+                -u {{cfg.user}} -g {{cfg.group}}\
+                --paths "{{cfg.project_root}}/www"\
+                --excludes=".*files.+";
              {{locs.resetperms}} -q --no-recursive --no-acls\
-               --fmode  664 -u {{cfg.user}} -g {{cfg.group}}\
+               --fmode  644 -u {{cfg.user}} -g {{cfg.group}}\
                --paths "{{cfg.project_root}}"/www/sites/default/settings.php\
                --paths "{{cfg.project_root}}"/www/sites/default/common.settings.php\
                --paths "{{cfg.project_root}}"/www/sites/default/local.settings.php\

--- a/.salt/fixperms.sls
+++ b/.salt/fixperms.sls
@@ -23,6 +23,29 @@
               --user root --group "{{cfg.group}}" \
               --dmode '0770' --fmode '0770' \
               --paths "{{cfg.pillar_root}}";
+             # web directory loop (user and groups rights)
+             find -H \
+               "{{cfg.project_root}}/www" \
+               \(\
+                    \( -type f -and \( -not -perm 0640 \) -and \( -not -path "{{cfg.project_root}}/www/sites/*/files*" \) \)\
+                -or \( -type d -and \( -not -perm 2751 \) -and \( -not -path "{{cfg.project_root}}/www/sites/*/files*" \) \)\
+               \)\
+               |\
+               while read i; do
+                   if [ ! -h "${i}" ]; then
+                       if [ -d "${i}" ]; then
+                           chmod g-s "${i}"
+                           chmod 751 "${i}"
+                           chmod g+s "${i}"
+                       fi
+                       if [ -f "${i}" ]; then
+                           chmod g-s "$(dirname "${i}")"
+                           chmod 0640 "${i}"
+                           chmod g+s "$(dirname "${i}")"
+                       fi
+                   fi
+               done
+            # general loop (ownership and setgid for directories)
             find -H \
               "{{cfg.project_root}}" \
               "{{cfg.data_root}}" {%if not cfg.remote_less %}"{{cfg.git_root}}"{% endif %} \
@@ -59,27 +82,6 @@
              #  --dmode 2771 -u root -g root \
              #  --paths "{{cfg.data_root}}"\
              #  --paths "{{cfg.data_root}}/var";
-             find -H \
-               "{{cfg.project_root}}/www" \
-               \(\
-                    \( -type f -and \( -not -perm 0640 \) -and \( -not -path "{{cfg.project_root}}/www/sites/*/files*" \) \)\
-                -or \( -type d -and \( -not -perm 2751 \) -and \( -not -path "{{cfg.project_root}}/www/sites/*/files*" \) \)\
-               \)\
-               |\
-               while read i; do
-                   if [ ! -h "${i}" ]; then
-                       if [ -d "${i}" ]; then
-                           chmod g-s "${i}"
-                           chmod 751 "${i}"
-                           chmod g+s "${i}"
-                       fi
-                       if [ -f "${i}" ]; then
-                           chmod g-s "$(dirname "${i}")"
-                           chmod 0640 "${i}"
-                           chmod g+s "$(dirname "${i}")"
-                       fi
-                   fi
-               done
              {{locs.resetperms}} -q --no-recursive --no-acls\
                --fmode  644 -u {{cfg.user}} -g {{cfg.group}}\
                --paths "{{cfg.project_root}}"/www/sites/default/settings.php\


### PR DESCRIPTION
- set file mode 640 group mode 2751 in www (except files)
- remove group write on settings (php-fpm), php user should not be able to alter settings (and drupal will agree on that in internal tests)

This will maybe mark some files as updated (script/*.sh from drupal after a fresh make, or bad modules files). But the fixperm will fix that via cron. And I wnt it to be fixed by the fixperm, which is more secure than git (git mode is 644 755).